### PR TITLE
Make copy-dir.js work on any OS

### DIFF
--- a/lib/utils/copy-dir.js
+++ b/lib/utils/copy-dir.js
@@ -1,8 +1,8 @@
-const execa = require('execa')
 const path = require('path')
 const Promise = require('promise')
 const messages = require('../messages')
 const output = require('./output')
+const fs = require('fs-extra')
 
 module.exports = function copyDir (opts) {
   const templatePath = opts.templatePath
@@ -14,12 +14,12 @@ module.exports = function copyDir (opts) {
   return new Promise(function (resolve, reject) {
     const stopCopySpinner = output.wait('Copying files')
 
-    execa('cp', ['-r', templatePath, projectPath])
+    fs.copy(templatePath, projectPath)
       .then(function () {
-        return execa('mv', [
+        return fs.move(
           path.resolve(projectPath, './gitignore'),
           path.resolve(projectPath, './.gitignore')
-        ])
+        )
       })
       .then(function () {
         stopCopySpinner()

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "commander": "^2.9.0",
     "cross-spawn": "^5.1.0",
     "execa": "^0.6.3",
+    "fs-extra": "^3.0.0",
     "mkdirp-then": "^1.2.0",
     "ms": "^1.0.0",
     "mz": "^2.6.0",


### PR DESCRIPTION
When using the app on Windows and creating an app with `create-next-app something`, it complains that it doesn't recognize `cp` command.

This fixes that, using [fs-extra](https://github.com/jprichardson/node-fs-extra) to handle `cp` and `mv`, so it should work on any OS.

References this issue #1 
