### PR TITLE
circle: remove gh-pages stuff & make use of yarn

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,32 +2,14 @@ machine:
   node:
     version: 6
 
-general:
-  branches:
-    ignore:
-      # we do not want to rebuild gh-pages, as all the "built" content will be removed
-      - gh-pages
-
-# set git config so we can commit/deploy to gh-pages
-checkout:
-  post:
-    - git config user.name "Circle CI"
-    - git config user.email "void@circle.com"
-
 dependencies:
   pre:
     # login for publishing permissions & private packages
     - npm config set "//registry.npmjs.org/:_authToken" $NPM_AUTH
-    # install Yarn
-    # see https://yarnpkg.com/en/docs/install-ci#circle-tab
-    - sudo apt-key adv --fetch-keys http://dl.yarnpkg.com/debian/pubkey.gpg
-    - echo "deb http://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list
-    - sudo apt-get update -qq
-    - sudo apt-get install -y -qq yarn
   cache_directories:
     - ~/.yarn-cache
   override:
-    - npm install
+    - yarn
 
 test:
   override:


### PR DESCRIPTION
This patch removes the unused `gh-pages` stuff (as the homepage for
this project lives on open.segment.com, not gh-pages) and makes better
use of our `yarn.lock` file by installing dependencies with `yarn`
rather than `npm`.