### PR TITLE
messages: suggest using `yarn <cmd>` when available

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,4 +1,5 @@
 const chalk = require('chalk')
+const getInstallCmd = require('./utils/get-install-cmd')
 const output = require('./utils/output')
 
 const program = {
@@ -64,24 +65,33 @@ Creating ${chalk.bold(chalk.green(projectName))}...
 }
 
 exports.start = function (projectName) {
+  const cmd = getInstallCmd()
+
+  const commands = {
+    install: cmd === 'npm' ? 'npm install' : 'yarn',
+    build: cmd === 'npm' ? 'npm run build' : 'yarn build',
+    start: cmd === 'npm' ? 'npm run start' : 'yarn start',
+    dev: cmd === 'npm' ? 'npm run dev' : 'yarn dev'
+  }
+
   return `
   ${chalk.green('Awesome!')} You're now ready to start coding.
 
-  We already ran ${output.cmd('npm install')} for you, so your next steps are:
+  We already ran ${output.cmd(commands.install)} for you, so your next steps are:
 
   $ ${output.cmd(`cd ${projectName}`)}
 
   To build a version for production:
 
-  $ ${output.cmd(`npm run build`)}
+  $ ${output.cmd(commands.build)}
 
   To run the server in production:
 
-  $ ${output.cmd(`npm run start`)}
+  $ ${output.cmd(commands.start)}
 
   To start a local server for development:
 
-  $ ${output.cmd(`npm run dev`)}
+  $ ${output.cmd(commands.dev)}
 
   Questions? Feedback? Please let us know!
 

--- a/lib/utils/get-install-cmd.js
+++ b/lib/utils/get-install-cmd.js
@@ -1,0 +1,18 @@
+const execa = require('execa')
+
+let cmd
+
+module.exports = function getInstallCmd () {
+  if (cmd) {
+    return cmd
+  }
+
+  try {
+    execa.sync('yarnpkg', '--version')
+    cmd = 'yarn'
+  } catch (e) {
+    cmd = 'npm'
+  }
+
+  return cmd
+}

--- a/lib/utils/install.js
+++ b/lib/utils/install.js
@@ -1,6 +1,7 @@
 const execa = require('execa')
 const Promise = require('promise')
 const messages = require('../messages')
+const getInstallCmd = require('./get-install-cmd')
 const output = require('./output')
 
 module.exports = function install (opts) {
@@ -13,8 +14,8 @@ module.exports = function install (opts) {
     process.exit(1)
   }
 
-  let installCmd = getInstallCmd()
-  let installArgs = getInstallArgs(installCmd, packages)
+  const installCmd = getInstallCmd()
+  const installArgs = getInstallArgs(installCmd, packages)
 
   console.log(messages.installing(packages))
   process.chdir(projectPath)
@@ -35,15 +36,6 @@ module.exports = function install (opts) {
       return reject(new Error(`${installCmd} installation failed`))
     })
   })
-}
-
-function getInstallCmd () {
-  try {
-    execa.sync('yarnpkg', '--version')
-    return 'yarn'
-  } catch (e) {
-    return 'npm'
-  }
 }
 
 function getInstallArgs (cmd, packages) {

--- a/lib/utils/load-example.js
+++ b/lib/utils/load-example.js
@@ -17,13 +17,8 @@ module.exports = function loadExample (opts) {
     return exec.shell(cmd)
   })
 
-  return new Promise(function (resolve, reject) {
-    Promise.all(cmdPromises).then(function () {
-      stopExampleSpinner()
-      output.success(`Downloaded ${output.cmd(example)} files for ${output.cmd(projectName)}`)
-      resolve()
-    }).catch(function (err) {
-      reject(err)
-    })
+  return Promise.all(cmdPromises).then(function () {
+    stopExampleSpinner()
+    output.success(`Downloaded ${output.cmd(example)} files for ${output.cmd(projectName)}`)
   })
 }


### PR DESCRIPTION
This patch changes the "start" messages to suggest using `yarn` (rather
than `npm run`) it's installed/available.