### PR TITLE
Default template imports fix

### DIFF
--- a/lib/templates/default/pages/index.js
+++ b/lib/templates/default/pages/index.js
@@ -1,6 +1,6 @@
 import Link from 'next/link'
-import Head from '../components/Head'
-import Nav from '../components/Nav'
+import Head from '../components/head'
+import Nav from '../components/nav'
 
 export default () => (
   <div>


### PR DESCRIPTION
The `Head` and `Nav` components imports are wrong in the default
template index.js file