### PR TITLE
fix: add check for current directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -14,7 +14,7 @@ module.exports = function createNextApp (opts) {
     process.exit(1)
   }
 
-  if (fs.existsSync(projectName)) {
+  if (fs.existsSync(projectName) && projectName !== '.') {
     console.log(messages.alreadyExists(projectName))
     process.exit(1)
   }


### PR DESCRIPTION
Added check to see if projectName is ".", to allow for creating a next app in the cwd. Before, it threw error: "directory already exists".

Thanks for creating this useful CLI 😀