### PR TITLE
Fix: Head should not be imported into Nav.js

### DIFF
--- a/lib/templates/default/components/nav.js
+++ b/lib/templates/default/components/nav.js
@@ -1,4 +1,3 @@
-import Head from './head'
 import Link from 'next/link'
 
 const links = [


### PR DESCRIPTION
The Head component was being imported into the Nav.js module but not used - this fix removes that unnecessary import.