### PR TITLE
Add catch if example requested doesn't exists

### DIFF
--- a/lib/utils/load-example.js
+++ b/lib/utils/load-example.js
@@ -20,5 +20,9 @@ module.exports = function loadExample (opts) {
   return Promise.all(cmdPromises).then(function () {
     stopExampleSpinner()
     output.success(`Downloaded ${output.cmd(example)} files for ${output.cmd(projectName)}`)
+  }).catch(function (err) {
+    stopExampleSpinner()
+    output.error(`Error downloading ${output.cmd(example)} files for ${output.cmd(projectName)}`)
+    throw err
   })
 }


### PR DESCRIPTION
I came across to this awesome `zero-config` lib from [this example](https://github.com/zeit/next.js/tree/canary/examples/with-algolia-react-instantsearch) and did an incomplete copy of the command, not the first time :|

<img width="902" alt="screen shot 2017-12-20 at 14 57 17" src="https://user-images.githubusercontent.com/784056/34210470-3b33951e-e596-11e7-9775-98bfa5ae85bc.png">

### current behaviour

As I didn't realize, was waiting the progress and the spinner finishes, but didn't happen.

![current behaviour](https://user-images.githubusercontent.com/784056/34210693-124bb63a-e597-11e7-9791-dbbaa14ca401.gif)

### proposed behaviour

So thought could be helpful to catch the `exec` promise in case didn't find the repo of the example requested.

![proposed behaviour](https://user-images.githubusercontent.com/784056/34210836-7ce72db2-e597-11e7-9de2-103d8755162e.gif)

