### PR TITLE
Camelcase charset for jsx

### DIFF
--- a/lib/templates/default/components/head.js
+++ b/lib/templates/default/components/head.js
@@ -7,7 +7,7 @@ const defaultOGImage = ''
 
 const Head = (props) => (
   <NextHead>
-    <meta charset="UTF-8" />
+    <meta charSet="UTF-8" />
     <title>{props.title || ''}</title>
     <meta name="description" content={props.description || defaultDescription} />
     <meta name="viewport" content="width=device-width, initial-scale=1" />


### PR DESCRIPTION
This gets rid of the warning below when running `yarn dev`
```Warning: Invalid DOM property `charset`. Did you mean `charSet`?```