### PR TITLE
Fix typo.

### DIFF
--- a/lib/templates/default/README.md
+++ b/lib/templates/default/README.md
@@ -169,7 +169,7 @@ Read more about [fetching data and the component lifecycle](https://github.com/z
 
 ## Custom Server
 
-Want to start a new app with a custom server? Run `create-next-app --example customer-server custom-app`
+Want to start a new app with a custom server? Run `create-next-app --example custom-server custom-app`
 
 Typically you start your next server with `next start`. It's possible, however, to start a server 100% programmatically in order to customize routes, use route patterns, etc
 


### PR DESCRIPTION
`customer-server` not found:

```
> Error! Error downloading customer-server files for custom-app
(node:78249) UnhandledPromiseRejectionWarning: HttpError: {"message":"Not Found","documentation_url":"https://developer.github.com/v3/repos/contents/#get-contents"}
    at response.text.then.message (/Users/pablo/.npm/_npx/78249/lib/node_modules/create-next-app/node_modules/@octokit/rest/lib/request/request.js:72:19)
    at processTicksAndRejections (internal/process/next_tick.js:81:5)
(node:78249) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:78249) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```