### PR TITLE
Fix GitHub spelling

### DIFF
--- a/lib/templates/default/components/nav.js
+++ b/lib/templates/default/components/nav.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from 'next/link'
 
 const links = [
-  { href: 'https://github.com/segmentio/create-next-app', label: 'Github' }
+  { href: 'https://github.com/segmentio/create-next-app', label: 'GitHub' }
 ].map(link => {
   link.key = `nav-link-${link.href}-${link.label}`
   return link

--- a/lib/templates/default/pages/index.js
+++ b/lib/templates/default/pages/index.js
@@ -18,7 +18,7 @@ const Home = () => (
         <Link href="https://github.com/zeit/next.js#getting-started">
           <a className="card">
             <h3>Getting Started &rarr;</h3>
-            <p>Learn more about Next on Github and in their examples</p>
+            <p>Learn more about Next on GitHub and in their examples</p>
           </a>
         </Link>
         <Link href="https://open.segment.com/create-next-app">

--- a/lib/utils/load-example.js
+++ b/lib/utils/load-example.js
@@ -2,13 +2,13 @@ const Promise = require('promise')
 const got = require('got')
 const mkdir = require('make-dir')
 const tar = require('tar')
-const Github = require('@octokit/rest')
+const Octokit = require('@octokit/rest')
 const output = require('./output')
 
 // Ensure the given `example` name has a package.json file
 // A "not found" error will be returned if not
 const validateExampleName = example =>
-  new Github().repos.getContent({
+  new Octokit().repos.getContent({
     owner: 'zeit',
     repo: 'next.js',
     path: `examples/${example}/package.json`


### PR DESCRIPTION
Just a minor typo fix: `Github` -> `GitHub`.